### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - if: ${{ matrix.engine == 'pdflatex' }}
         name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
@@ -29,7 +29,7 @@ jobs:
           latexmk_shell_escape: true
           latexmk_use_lualatex: true
       - name: Upload the compiled pdf
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         with:
           name: thesis-${{ matrix.engine }}
           path: |


### PR DESCRIPTION
The current version shows this warning:

```
build_latex (pdflatex)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2.2.4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

This modification will fix it.