### PR TITLE
Fix wrong line spacing in multi-line titles

### DIFF
--- a/elteikthesis.cls
+++ b/elteikthesis.cls
@@ -488,7 +488,7 @@
 			\end{tabular}
 
 			\vspace{5.0cm}
-			{\bf \LARGE \thesistitle}
+			{\bf \LARGE \thesistitle \par}
 			\vspace{4.0cm}
 
 			\ifdefined\extsupaff


### PR DESCRIPTION
This patch makes sure that line spacing is the same for every line in a multi-line title.

Someone might insert line breaks into the title the following way:
```latex
\title{
Multi\\
Line\\
Title
} % title
```
Without this change, the title would be rendered with a different spacing between the 
different lines. See in the pictures below.

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/65320245/215810888-5e378885-c485-4795-a36f-d1fb739c2ed5.png) | ![after](https://user-images.githubusercontent.com/65320245/215810880-c80037f7-7846-45b9-b840-e1caf24bfbd1.png)  |




