### PR TITLE
Fix minted example mention

### DIFF
--- a/elteikthesis_en.tex
+++ b/elteikthesis_en.tex
@@ -8,7 +8,7 @@
 ]{elteikthesis}[2023/04/10]
 
 % The minted package is also supported for source highlighting
-% See minted-intregration.tex for example
+% See elteikthesis_minted.tex for example
 %\usepackage[newfloat]{minted}
 
 % Document's metadata

--- a/elteikthesis_hu.tex
+++ b/elteikthesis_hu.tex
@@ -8,7 +8,7 @@
 ]{elteikthesis}[2023/04/10]
 
 % The minted package is also supported for source highlighting
-% See minted-intregration.tex for example
+% See elteikthesis_minted.tex for example
 %\usepackage[newfloat]{minted}
 
 % Document's metadata


### PR DESCRIPTION
The file mentioned in the elteikthesis documents has been renamed in 08f589a8310a5d32fd006220293f7e46511a8bd9. This pull request updates the mentions to use the new filename.